### PR TITLE
Add more options for interpolator classes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include *.md
 recursive-include notebooks *.ipynb
 recursive-include notebooks *.py
 recursive-include pycomlink/io/example_data *
+recursive-include pycomlink/tests/test_data *
 
 recursive-exclude notebooks __init__.py
 recursive-exclude notebooks *.pyc

--- a/pycomlink/spatial/idw.py
+++ b/pycomlink/spatial/idw.py
@@ -73,9 +73,19 @@ class Invdisttree(object):
         self.wsum = None
         self.q = None
 
-    def __call__(self, q, z, nnear=6, eps=0, p=1, weights=None):
-            # nnear nearest neighbours of each query point --
+    def __call__(self,
+                 q,
+                 z,
+                 nnear=6,
+                 eps=0,
+                 p=1,
+                 weights=None,
+                 max_distance=None):
+        # nnear nearest neighbours of each query point --
         assert len(self.X) == len(z), "len(X) %d != len(z) %d" % (len(self.X), len(z))
+
+        if max_distance is None:
+            max_distance = np.inf
 
         if nnear <= 1:
             raise ValueError('`nnear` must be greater than 1')
@@ -98,7 +108,11 @@ class Invdisttree(object):
             # print 'reuse `distances`'
             pass
         else:
-            self.distances, self.ix = self.tree.query(q, k=nnear, eps=eps)
+            self.distances, self.ix = self.tree.query(
+                q,
+                k=nnear,
+                eps=eps,
+                distance_upper_bound=max_distance)
             self.q = q
             self.nnear = nnear
             self.eps = eps

--- a/pycomlink/spatial/interpolator.py
+++ b/pycomlink/spatial/interpolator.py
@@ -130,7 +130,13 @@ class ComlinkGridInterpolator(object):
                  xgrid=None,
                  ygrid=None,
                  resolution=None,
-                 interpolator=IdwKdtreeInterpolator()):
+                 interpolator=IdwKdtreeInterpolator(),
+                 resample_to='H',
+                 resample_label='right',
+                 variable='R',
+                 channels=['channel_1'],
+                 aggregation_func=np.mean,
+                 apply_factor=1):
 
         self.lons, self.lats = get_lon_lat_list_from_cml_list(cml_list)
         # Later some coordinate transformations can be added here
@@ -138,7 +144,15 @@ class ComlinkGridInterpolator(object):
         self.y = self.lats
 
         # TODO: Forward arguments to select aggregation type and frequency
-        self.df_cmls = get_dataframe_for_cml_variable(cml_list)
+        self.df_cmls = get_dataframe_for_cml_variable(
+            cml_list,
+            resample_to=resample_to,
+            resample_label=resample_label,
+            variable=variable,
+            channels=channels,
+            aggregation_func=aggregation_func,
+            apply_factor=apply_factor)
+
         self._interpolator = interpolator
         self.resolution = resolution
 

--- a/pycomlink/spatial/interpolator.py
+++ b/pycomlink/spatial/interpolator.py
@@ -49,11 +49,12 @@ class PointsToGridInterpolator(with_metaclass(abc.ABCMeta, object)):
 
 
 class IdwKdtreeInterpolator(PointsToGridInterpolator):
-    def __init__(self, nnear=8, p=2, exclude_nan=True):
+    def __init__(self, nnear=8, p=2, exclude_nan=True, max_distance=None):
         """ A k-d tree based IDW interpolator for points to grid """
         self.nnear = nnear
         self.p = p
         self.exclude_nan = exclude_nan
+        self.max_distance = max_distance
         self.x = None
         self.y = None
 
@@ -83,7 +84,8 @@ class IdwKdtreeInterpolator(PointsToGridInterpolator):
         zi = idw(q=list(zip(xi, yi)),
                  z=z,
                  nnear=self.nnear,
-                 p=self.p)
+                 p=self.p,
+                 max_distance=self.max_distance)
         return zi
 
 

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -1,0 +1,32 @@
+import unittest
+
+import pycomlink as pycml
+
+
+class TestIdwKdtreeInterpolator(unittest.TestCase):
+    def test_without_nans(self):
+        pass
+
+    def test_with_nans(self):
+        pass
+
+
+class TestOrdiniaryKrigingInterpolator(unittest.TestCase):
+    def test_without_nans(self):
+        pass
+
+    def test_with_nans(self):
+        pass
+
+
+class TestComlinkGridInterpolator(unittest.TestCase):
+    def test_temporal_aggregation(self):
+        cml_list = pycml.io.examples.get_75_cmls()
+
+        interpolator = pycml.spatial.interpolator.ComlinkGridInterpolator(
+            cml_list=cml_list,
+            variable='rx',
+            resolution=0.05,
+            interpolator=pycml.spatial.interpolator.IdwKdtreeInterpolator())
+
+        pass

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 import pycomlink as pycml
-from pycomlink.tests.utils import load_and_clean_example_cml_list
+from pycomlink.tests.utils import load_processed_cml_list
 
 
 class TestIdwKdtreeInterpolator(unittest.TestCase):
@@ -22,11 +22,11 @@ class TestOrdiniaryKrigingInterpolator(unittest.TestCase):
 
 class TestComlinkGridInterpolator(unittest.TestCase):
     def test_default_idw(self):
-        cml_list = load_and_clean_example_cml_list()
+        cml_list = load_processed_cml_list()
 
         interpolator = pycml.spatial.interpolator.ComlinkGridInterpolator(
             cml_list=cml_list,
-            variable='rx',
+            variable='R',
             resolution=0.05,
             interpolator=pycml.spatial.interpolator.IdwKdtreeInterpolator())
 
@@ -35,36 +35,38 @@ class TestComlinkGridInterpolator(unittest.TestCase):
         assert zgrid[0].shape == (16, 23)
 
         np.testing.assert_array_almost_equal(zgrid[10][1:4, 1:4], np.array(
-            [[-46.85263666, -46.87468505, -46.21003706],
-             [-46.70700606, -46.92331939, -46.92513674],
-             [-46.15441647, -46.55741421, -46.39807402]]))
+            [[0., 0., 0.],
+             [0.02679148, 0., 0.],
+             [0.17902197, 0.10871572, 0.]]))
 
         np.testing.assert_array_almost_equal(zgrid[20][1:4, 1:4], np.array(
-            [[-46.86313914, -46.89160703, -46.26548933],
-             [-46.71264833, -46.92780239, -46.96490213],
-             [-46.11732763, -46.53814125, -46.4805056]]))
+            [[0.01852385, 0.08876891, 0.14781145],
+             [0.05900791, 0.15852366, 0.14716676],
+             [0.16692699, 0.16040398, 0.11649888]]))
 
         zgrid_i = interpolator.interpolate_for_i(3)
         np.testing.assert_array_almost_equal(zgrid_i[1:4, 1:4], np.array(
-            [[-46.84939582, -46.89709485, -46.26185758],
-             [-46.71798389, -46.96183674, -46.97195592],
-             [-46.12521554, -46.55562653, -46.48171999]]))
+            [[0.04484675, 0.12339762, 0.1185833],
+             [0.07857356, 0.26151277, 0.13641106],
+             [0.2014109, 0.19460449, 0.08598332]]))
 
     def test_default_kriging(self):
-        cml_list = load_and_clean_example_cml_list()
+        cml_list = load_processed_cml_list()
 
+        # TODO: Use 'C' backend when available via pip installed pykirge
         interpolator = pycml.spatial.interpolator.ComlinkGridInterpolator(
             cml_list=cml_list,
-            variable='rx',
+            variable='R',
             resolution=0.05,
             interpolator=(pycml.spatial.interpolator.
-                          OrdinaryKrigingInterpolator()))
+                          OrdinaryKrigingInterpolator(backend='loop')))
 
         zgrid = interpolator.loop_over_time()
 
         assert zgrid[0].shape == (16, 23)
 
-        np.testing.assert_array_almost_equal(zgrid[10][1:4, 1:4], np.array(
-            [[-46.37344738, -46.37336952, -46.37318653],
-             [-45.62199173, -46.37342665, -46.37327972],
-             [-45.25576347, -45.25585099, -46.01024901]]))
+        # TODO: Check if theses results change when using the 'C' backend
+        np.testing.assert_array_almost_equal(zgrid[24][1:4, 1:4], np.array(
+            [[2.41876631, 3.55747763, 5.21045399],
+             [2.59474309, 3.74337047, 4.95187848],
+             [2.89174467, 3.57024647, 4.49247846]]))

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -1,6 +1,7 @@
 import unittest
-
+import numpy as np
 import pycomlink as pycml
+from pycomlink.tests.utils import load_and_clean_example_cml_list
 
 
 class TestIdwKdtreeInterpolator(unittest.TestCase):
@@ -20,8 +21,8 @@ class TestOrdiniaryKrigingInterpolator(unittest.TestCase):
 
 
 class TestComlinkGridInterpolator(unittest.TestCase):
-    def test_temporal_aggregation(self):
-        cml_list = pycml.io.examples.get_75_cmls()
+    def test_default_idw(self):
+        cml_list = load_and_clean_example_cml_list()
 
         interpolator = pycml.spatial.interpolator.ComlinkGridInterpolator(
             cml_list=cml_list,
@@ -29,4 +30,41 @@ class TestComlinkGridInterpolator(unittest.TestCase):
             resolution=0.05,
             interpolator=pycml.spatial.interpolator.IdwKdtreeInterpolator())
 
-        pass
+        zgrid = interpolator.loop_over_time()
+
+        assert zgrid[0].shape == (16, 23)
+
+        np.testing.assert_array_almost_equal(zgrid[10][1:4, 1:4], np.array(
+            [[-46.85263666, -46.87468505, -46.21003706],
+             [-46.70700606, -46.92331939, -46.92513674],
+             [-46.15441647, -46.55741421, -46.39807402]]))
+
+        np.testing.assert_array_almost_equal(zgrid[20][1:4, 1:4], np.array(
+            [[-46.86313914, -46.89160703, -46.26548933],
+             [-46.71264833, -46.92780239, -46.96490213],
+             [-46.11732763, -46.53814125, -46.4805056]]))
+
+        zgrid_i = interpolator.interpolate_for_i(3)
+        np.testing.assert_array_almost_equal(zgrid_i[1:4, 1:4], np.array(
+            [[-46.84939582, -46.89709485, -46.26185758],
+             [-46.71798389, -46.96183674, -46.97195592],
+             [-46.12521554, -46.55562653, -46.48171999]]))
+
+    def test_default_kriging(self):
+        cml_list = load_and_clean_example_cml_list()
+
+        interpolator = pycml.spatial.interpolator.ComlinkGridInterpolator(
+            cml_list=cml_list,
+            variable='rx',
+            resolution=0.05,
+            interpolator=(pycml.spatial.interpolator.
+                          OrdinaryKrigingInterpolator()))
+
+        zgrid = interpolator.loop_over_time()
+
+        assert zgrid[0].shape == (16, 23)
+
+        np.testing.assert_array_almost_equal(zgrid[10][1:4, 1:4], np.array(
+            [[-46.37344738, -46.37336952, -46.37318653],
+             [-45.62199173, -46.37342665, -46.37327972],
+             [-45.25576347, -45.25585099, -46.01024901]]))

--- a/pycomlink/tests/test_processor.py
+++ b/pycomlink/tests/test_processor.py
@@ -1,19 +1,10 @@
 import unittest
-
-import pycomlink as pycml
-
-def load_and_clean_example_data():
-    cml = pycml.io.examples.read_one_cml()
-    cml.process.quality_control.set_to_nan_if('tx', '>=', 100)
-    cml.process.quality_control.set_to_nan_if('rx', '==', -99.9)
-    for cml_ch in cml.channels.values():
-        cml_ch.data.interpolate(limit=3)
-    return cml
+from pycomlink.tests.utils import load_and_clean_example_cml
 
 
 class TestWetDryStdDev(unittest.TestCase):
     def test_standrad_processing(self):
-        cml = load_and_clean_example_data()
+        cml = load_and_clean_example_cml()
         cml.process.wet_dry.std_dev(window_length=60, threshold=0.8)
 
         assert (cml.channel_1.data.wet.loc['2016-11-02 14:00'].values[0]
@@ -43,7 +34,7 @@ class TestWetDryStdDev(unittest.TestCase):
                 == True)
 
     def test_processing_for_selected_time_period(self):
-        cml = load_and_clean_example_data()
+        cml = load_and_clean_example_cml()
 
         # First as a comparisson the standard way
         cml.process.wet_dry.std_dev(window_length=60, threshold=0.8)

--- a/pycomlink/tests/utils.py
+++ b/pycomlink/tests/utils.py
@@ -1,4 +1,10 @@
+import pkg_resources
+import os.path
 import pycomlink as pycml
+
+
+def get_test_data_path():
+    return pkg_resources.resource_filename('pycomlink', 'tests/test_data')
 
 
 def load_and_clean_example_cml():
@@ -10,11 +16,8 @@ def load_and_clean_example_cml():
     return cml
 
 
-def load_and_clean_example_cml_list():
-    cml_list = pycml.io.examples.get_75_cmls()
-    for cml in cml_list:
-        cml.process.quality_control.set_to_nan_if('tx', '>=', 100)
-        cml.process.quality_control.set_to_nan_if('rx', '==', -99.9)
-        for cml_ch in cml.channels.values():
-            cml_ch.data.interpolate(limit=3)
-    return cml_list
+def load_processed_cml_list():
+    data_path = get_test_data_path()
+    fn = '75_cmls_processed.h5'
+    return pycml.io.read_from_cmlh5(os.path.join(data_path, fn),
+                                    read_all_data=True)

--- a/pycomlink/tests/utils.py
+++ b/pycomlink/tests/utils.py
@@ -1,0 +1,20 @@
+import pycomlink as pycml
+
+
+def load_and_clean_example_cml():
+    cml = pycml.io.examples.read_one_cml()
+    cml.process.quality_control.set_to_nan_if('tx', '>=', 100)
+    cml.process.quality_control.set_to_nan_if('rx', '==', -99.9)
+    for cml_ch in cml.channels.values():
+        cml_ch.data.interpolate(limit=3)
+    return cml
+
+
+def load_and_clean_example_cml_list():
+    cml_list = pycml.io.examples.get_75_cmls()
+    for cml in cml_list:
+        cml.process.quality_control.set_to_nan_if('tx', '>=', 100)
+        cml.process.quality_control.set_to_nan_if('rx', '==', -99.9)
+        for cml_ch in cml.channels.values():
+            cml_ch.data.interpolate(limit=3)
+    return cml_list


### PR DESCRIPTION
In addition to what is covered in the commit messages, the defaults arguments for the `OrdinaryKrigingInterpolator` have been changed.