### PR TITLE
FIX: fixed problem with reordered dataframe columns in interpolator

### DIFF
--- a/pycomlink/spatial/interpolator.py
+++ b/pycomlink/spatial/interpolator.py
@@ -410,6 +410,14 @@ def get_dataframe_for_cml_variable(cml_list,
                 .apply(aggregation_func))
         df = pd.concat(df_dict, axis=1)
 
+    # Assure the correct order of the columns.
+    # Please note that the order of the columns might get mixed up even if a
+    # OrderdDictionary of DataFrames is used for concatenation. Reordering
+    # the columns is computationally cheap compare to the rest of the
+    # interpolation.
+    cml_id_list = [cml.metadata['cml_id'] for cml in cml_list]
+    df = df[cml_id_list]
+
     df *= apply_factor
 
     return df

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -128,11 +128,11 @@ class TestGetDataFrameForCmlVariable(unittest.TestCase):
         # Add two CMLs with new fake cml_id (which are very different from
         # the example cml_ids to cause mixing order of their hashed values)
         cml_temp = copy.deepcopy(cml_list[0])
-        cml_temp.metadata['cml_id'] = 'some_really_long_cml_id_122334567'
+        cml_temp.metadata['cml_id'] = u'some_really_long_cml_id_122334567'
         cml_list.insert(0, cml_temp)
 
         cml_temp = copy.deepcopy(cml_list[0])
-        cml_temp.metadata['cml_id'] = 'another_really_long_cml_id_999222123123'
+        cml_temp.metadata['cml_id'] = u'another_really_long_cml_id_999222123123'
         cml_list.append(cml_temp)
 
         df = pycml.spatial.interpolator.get_dataframe_for_cml_variable(

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -128,11 +128,11 @@ class TestGetDataFrameForCmlVariable(unittest.TestCase):
         # Add two CMLs with new fake cml_id (which are very different from
         # the example cml_ids to cause mixing order of their hashed values)
         cml_temp = copy.deepcopy(cml_list[0])
-        cml_temp.metadata['cml_id'] = u'some_really_long_cml_id_122334567'
+        cml_temp.metadata['cml_id'] = b'some_really_long_cml_id_122334567'
         cml_list.insert(0, cml_temp)
 
         cml_temp = copy.deepcopy(cml_list[0])
-        cml_temp.metadata['cml_id'] = u'another_really_long_cml_id_999222123123'
+        cml_temp.metadata['cml_id'] = b'another_really_long_cml_id_999222123123'
         cml_list.append(cml_temp)
 
         df = pycml.spatial.interpolator.get_dataframe_for_cml_variable(

--- a/pycomlink/tests/test_interpolator.py
+++ b/pycomlink/tests/test_interpolator.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 import numpy as np
 import pandas as pd
 import pycomlink as pycml
@@ -118,3 +119,23 @@ class TestComlinkGridInterpolator(unittest.TestCase):
             np.array([[2.41876631, 3.55747763, 5.21045399],
                       [2.59474309, 3.74337047, 4.95187848],
                       [2.89174467, 3.57024647, 4.49247846]]))
+
+
+class TestGetDataFrameForCmlVariable(unittest.TestCase):
+    def test_cml_id_order(self):
+        cml_list = load_processed_cml_list()
+
+        # Add two CMLs with new fake cml_id (which are very different from
+        # the example cml_ids to cause mixing order of their hashed values)
+        cml_temp = copy.deepcopy(cml_list[0])
+        cml_temp.metadata['cml_id'] = 'some_really_long_cml_id_122334567'
+        cml_list.insert(0, cml_temp)
+
+        cml_temp = copy.deepcopy(cml_list[0])
+        cml_temp.metadata['cml_id'] = 'another_really_long_cml_id_999222123123'
+        cml_list.append(cml_temp)
+
+        df = pycml.spatial.interpolator.get_dataframe_for_cml_variable(
+            cml_list=cml_list)
+        for df_column_name, cml in zip(df.columns.tolist(), cml_list):
+            assert df_column_name == cml.metadata['cml_id']


### PR DESCRIPTION
The existing test did not reveal this problem since the order of the columns in the aggregated dataframe `df_cmls` in `ComlinkGridInterpolatorer` did not get messed up with the example data set of 75 CMLs. Only a real test case with 4000 CMLs changes the order of the columns, producing garbage interpolated fields, since the latitude and longitude values for the cmls are stored in lists with the order of the original `cml_list`. 

Interestingly, also a `OrderdDictionary` of DataFrames does not guarantee the order of the concated DataFrame columns.

With this PR the order should be fixed