### PR TITLE
FIX: Unpredictable order of ComlinkChannels

### DIFF
--- a/pycomlink/core/comlink.py
+++ b/pycomlink/core/comlink.py
@@ -18,7 +18,7 @@ from builtins import str
 from builtins import object
 import warnings
 from copy import deepcopy
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -104,7 +104,7 @@ class Comlink(object):
                               'has no effect, since they are already '
                               'contained in the supplied ComlinkChannel')
 
-        self.channels = _channels_list_to_dict(channels)
+        self.channels = _channels_list_to_ordered_dict(channels)
 
         self.metadata = {'site_a_latitude': metadata['site_a_latitude'],
                          'site_a_longitude': metadata['site_a_longitude'],
@@ -359,7 +359,7 @@ class Comlink(object):
                 max_age=max_age)
 
 
-def _channels_list_to_dict(channels):
+def _channels_list_to_ordered_dict(channels):
     """ Helper function to parse a list of channels to a dict of channels
 
     The keys will be `channel_(i+1)`, where i is the index of the list of
@@ -378,7 +378,7 @@ def _channels_list_to_dict(channels):
     channel_dict : dict
 
     """
-    channel_dict = {}
+    channel_dict = OrderedDict()
     for i, channel in enumerate(channels):
         channel_dict['channel_' + str(i+1)] = channel
     return channel_dict


### PR DESCRIPTION
`ComlinkChannels` have been stored in a dict in a `Comlink` object. This led to an unpredictable order. In particular after writing to cmlh5 and reading back in this is undesirable since writing to cmlh5 just iterates through the `Comlink.channels` dict and count upwards for naming the channels in the cmlh5 file.

This PR introduces a very simple fix for that by using an `OrderedDict` to store the `ComlinkChannels`.