### PR TITLE
FIX: MCC behavior when division by zero

### DIFF
--- a/pycomlink/tests/test_stats.py
+++ b/pycomlink/tests/test_stats.py
@@ -29,6 +29,19 @@ class TestWetDryandRainErrorfunctions(unittest.TestCase):
             wd_error,
             ref)
 
+    # the mcc should be zero, when predicted only contains false/zeros
+    def test_mcc_with_zero_wet_prediction(self):
+        reference = np.array([True, False, False])
+        predicted = np.array([False, False, False])
+
+        wd_error = pycml.validation.stats.calc_wet_dry_performance_metrics(
+            reference,
+            predicted)
+
+        np.testing.assert_array_almost_equal(
+            wd_error.matthews_correlation,
+            0)
+
     def test_RainError_with_simple_arrays(self):
         reference = np.array([1, 0, 1, 1, 1, 0, 1, 0, np.nan, np.nan, np.nan])
         predicted = np.array([1, 0, 0, 0, 1, 1, 0.01, 1, 1, 0, np.nan])

--- a/pycomlink/validation/stats.py
+++ b/pycomlink/validation/stats.py
@@ -181,7 +181,7 @@ def calc_wet_dry_performance_metrics(reference, predicted):
                                     (N_tn+N_fp)*(N_tn+N_fn)))
     # if predicted has zero/false values only
     # 'inf' would be returned, but 0 is more favorable
-    if matthews_correlation == float("inf"):
+    if np.isinf(matthews_correlation):
         matthews_correlation = 0
 
     return WetDryError(false_wet_rate=false_wet_rate,

--- a/pycomlink/validation/stats.py
+++ b/pycomlink/validation/stats.py
@@ -179,6 +179,10 @@ def calc_wet_dry_performance_metrics(reference, predicted):
     matthews_correlation = ((N_tp*N_tn-N_fp+N_fn) /
                             np.sqrt((N_tp+N_fp)*(N_tp+N_fn) *
                                     (N_tn+N_fp)*(N_tn+N_fn)))
+    # if predicted has zero/false values only
+    # 'inf' would be returned, but 0 is more favorable
+    if matthews_correlation == float("inf"):
+        matthews_correlation = 0
 
     return WetDryError(false_wet_rate=false_wet_rate,
                        missed_wet_rate=missed_wet_rate,


### PR DESCRIPTION
Added a test and a fix for the behavior of mcc when the predicted series contains only zeros/false. Now a mcc of 0 is returned similar to the [edge case handling of `scikit-learn`](https://github.com/scikit-learn/scikit-learn/blob/1495f6924/sklearn/metrics/classification.py#L793).