### PR TITLE
Add "pytest" and change instruction for development usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ and `ipython`, both also available via `conda` or `pip`.
 
 If you want to clone the repository for developing purposes follow these steps (installation of Jupyter Notebook included):
 
-    $ cd WORKING_DIRECTORY
     $ git clone https://github.com/pycomlink/pycomlink.git
-    $ conda env create --name ENV_NAME -file=environment_dev.yml
-    $ conda activate ENV_NAME
-    $ pip install -e WORKING_DIRECTORY/pycomlink
+    $ cd pycomlink
+    $ conda env create environment_dev.yml
+    $ conda activate pycomlink-dev
+    $ cd ..
+    $ pip install -e pycomlink
 
 Usage
 -----

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -19,3 +19,4 @@ dependencies:
  - jupyterlab
  - notebook
  - bottleneck
+ - pytest


### PR DESCRIPTION
Added "pytest" package to environment_dev.yml. The package is needed for running the tests. 

Additionally, instruction in README.md on how to use pycomlink as a developer was not totally clear, and therefore was changed slightly. This involves that custom naming of environment is not considered anymore as it is not necessary.