### PR TITLE
pin scipy to < 1.9 because of problem in pykrige

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
  - numpy
- - scipy
+ - scipy<1.9
  - pandas>=0.22
  - matplotlib
  - numba

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
  - numpy
- - scipy
+ - scipy<1.9
  - pandas>=0.22
  - matplotlib
  - numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy<1.9
 pandas>=0.22
 matplotlib
 numba


### PR DESCRIPTION
Current pykrige does not work with newest scipy https://github.com/GeoStat-Framework/PyKrige/pull/237