### PR TITLE
Drop Python 3.7 and Python 3.8 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python toolbox for deriving rainfall information from commercial microwave lin
 Installation
 ------------
 
-`pycomlink` is tested with Python 3.9 and 3.10. There have been problems with Python 3.8, see https://github.com/pycomlink/pycomlink/pull/120. Many things might work with older version, but there is no support for this
+`pycomlink` is tested with Python 3.9 and 3.10. There have been problems with Python 3.8, see https://github.com/pycomlink/pycomlink/pull/120. Many things might work with older version, but there is no support for this.
 
 It can be installed via [`conda-forge`](https://conda-forge.org/):
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A python toolbox for deriving rainfall information from commercial microwave lin
 Installation
 ------------
 
-`pycomlink` is tested with Python 3.7, 3.8 and 3.9. It should also work without problems on Python 3.6. It might still work with Python 2.7, but this is not tested. It can be installed via [`conda-forge`](https://conda-forge.org/):
+`pycomlink` is tested with Python 3.9 and 3.10. There have been problems with Python 3.8, see https://github.com/pycomlink/pycomlink/pull/120. Many things might work with older version, but there is no support for this
+
+It can be installed via [`conda-forge`](https://conda-forge.org/):
 
     $ conda install -c conda-forge pycomlink
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
     ],
     # A list of all available classifiers can be found at 
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
         "Development Status :: 3 - Alpha",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
         "License :: OSI Approved :: BSD License",
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     # A list of all available classifiers can be found at 
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
CI failed for Python 3.8 after merging #119. It seems to be caused by pandas 2.0 stuff that is called from xarray. Since xarray dropped support for Python 3.8 (see https://github.com/pydata/xarray/pull/7461) we will also do this since we heavily rely on xarray.

This should also be mentioned in the README.