### PR TITLE
Fixing order of coordinates in read_cmlh5_file_to_xarray

### DIFF
--- a/pycomlink/io/cmlh5_to_xarray.py
+++ b/pycomlink/io/cmlh5_to_xarray.py
@@ -49,10 +49,10 @@ def read_cmlh5_file_to_xarray(filename):
                     "frequency": cml_ch_g.attrs["frequency"] / 1e9,
                     "polarization": cml_ch_g.attrs["polarization"],
                     "length": haversine(
-                        cml_g.attrs["site_a_latitude"],
                         cml_g.attrs["site_a_longitude"],
-                        cml_g.attrs["site_b_latitude"],
+                        cml_g.attrs["site_a_latitude"],
                         cml_g.attrs["site_b_longitude"],
+                        cml_g.attrs["site_b_latitude"],
                     ),
                 },
             )


### PR DESCRIPTION
This fix solves #137 by correcting the order of coordinates used to calculate the CML length.