### PR TITLE
Implementing a more flexibel data ingest for a_b()

### DIFF
--- a/pycomlink/processing/k_R_relation.py
+++ b/pycomlink/processing/k_R_relation.py
@@ -187,13 +187,14 @@ def a_b(f_GHz, pol, approx_type="ITU_2005"):
     """
     if isinstance(f_GHz, xr.DataArray):
         return_xarray = True
+        f_GHz_coords = f_GHz.coords
     else:
         return_xarray = False
 
     f_GHz = xr.DataArray(f_GHz)
 
     if isinstance(pol, str):
-        pol = np.full_like(f_GHz, pol, dtype=object)
+        pol = xr.full_like(f_GHz, pol, dtype=object)
     pol = xr.DataArray(pol)
 
     tmp_dims_f_GHz = f_GHz.dims
@@ -244,8 +245,9 @@ def a_b(f_GHz, pol, approx_type="ITU_2005"):
     b[pol_mask_v] = b_v[pol_mask_v]
 
     if return_xarray:
-        a = xr.DataArray(a, dims=tmp_dims_f_GHz)
-        b = xr.DataArray(b, dims=tmp_dims_f_GHz)
+        if tmp_dims_f_GHz != ():
+            a = xr.DataArray(a, coords=f_GHz_coords)
+            b = xr.DataArray(b, coords=f_GHz_coords)
 
     return a, b
 

--- a/pycomlink/processing/k_R_relation.py
+++ b/pycomlink/processing/k_R_relation.py
@@ -43,7 +43,7 @@ def calc_R_from_A(
         are also allowed. Has to be provided together with `f_GHz`. It will be
         used to derive the parameters a and b for the k-R power law. Must have
         same shape as f_GHz or be a str. If it is a str, it will be expanded to
-        the shape of g_GHz.
+        the shape of f_GHz.
     a : float, optional
         Parameter of A-R relationship
     b : float, optional

--- a/pycomlink/processing/k_R_relation.py
+++ b/pycomlink/processing/k_R_relation.py
@@ -232,8 +232,8 @@ def a_b(f_GHz, pol, approx_type="ITU_2005"):
     a_h = interp_a_h(f_GHz)
     b_h = interp_b_h(f_GHz)
 
-    a = np.full_like(f_GHz, fill_value=np.nan)
-    b = np.full_like(f_GHz, fill_value=np.nan)
+    a = np.full_like(f_GHz, fill_value=np.nan, dtype=float)
+    b = np.full_like(f_GHz, fill_value=np.nan, dtype=float)
 
     pol_mask_v = np.isin(pol, pol_v_str_variants)
     pol_mask_h = np.isin(pol, pol_h_str_variants)

--- a/pycomlink/processing/k_R_relation.py
+++ b/pycomlink/processing/k_R_relation.py
@@ -34,13 +34,16 @@ def calc_R_from_A(
         Path-integrated attenuation of microwave link signal
     L_km : float
         Length of the link in km
-    f_GHz : float, optional
+    f_GHz : float, np.array, or xr.DataArray optional
         Frequency in GHz. If provided together with `pol`, it will be used to
         derive the parameters a and b for the k-R power law.
-    pol : string, optional
-        Polarization, that is either 'H' for horizontal or 'V' for vertical. Has
-        to be provided together with `f_GHz`. It will be used to derive the
-        parameters a and b for the k-R power law.
+    pol : string, np.array or xr.DataArray optional
+        Polarization, that is either 'horizontal' for horizontal or 'vertical'
+        for vertical. 'H', 'h' and 'Horizontal' as well as 'V', 'v' and 'Vertical'
+        are also allowed. Has to be provided together with `f_GHz`. It will be
+        used to derive the parameters a and b for the k-R power law. Must have
+        same shape as f_GHz or be a str. If it is a str, it will be expanded to
+        the shape of g_GHz.
     a : float, optional
         Parameter of A-R relationship
     b : float, optional
@@ -163,15 +166,17 @@ def a_b(f_GHz, pol, approx_type="ITU_2005"):
 
     Parameters
     ----------
-    f_GHz : int, float, np.array or xr.DataArray or iterable of these
-            Frequency of the microwave link in GHz. The data type of pol depends
-            on the data type of F_GHz.
-    pol : str, np.array 
-            Polarization of the microwave link
+    f_GHz : int, float, np.array or xr.DataArray
+        Frequency of the microwave link(s) in GHz.
+    pol : str, np.array or xr.DataArray
+        Polarization, that is either 'horizontal' for horizontal or 'vertical'
+        for vertical. 'H', 'h' and 'Horizontal' as well as 'V', 'v' and 'Vertical'
+        are also allowed. Must have same shape as f_GHz or be a str. If it is a
+        str, it will be expanded to the shape of f_GHz.
     approx_type : str, optional
-            Approximation type (the default is 'ITU_2005', which implies parameter
-            approximation using a table recommanded by ITU in 2005. An older version
-            of 2003 is available via 'ITU_2003'.)
+        Approximation type (the default is 'ITU_2005', which implies parameter
+        approximation using a table recommanded by ITU in 2005. An older version
+        of 2003 is available via 'ITU_2003'.)
 
     Returns
     -------

--- a/pycomlink/tests/test_k_R_relation.py
+++ b/pycomlink/tests/test_k_R_relation.py
@@ -197,6 +197,7 @@ class Test_a_b(unittest.TestCase):
             k_R_relation.a_b(30, "H", approx_type="ITU_2000")
 
 
+
 class Test_calc_R_from_A(unittest.TestCase):
     def test_with_int(self):
         A = 5
@@ -245,7 +246,7 @@ class Test_calc_R_from_A(unittest.TestCase):
         with self.assertRaises(ValueError):
             # pol and F_GHz as xr.DataArray but with different size
             calculated_R = k_R_relation.calc_R_from_A(
-                A=2, L_km=42, f_GHz=xr.DataArray([10,10]), pol=xr.DataArray("H"), a=1)
+                A=2, L_km=42, f_GHz=xr.DataArray([10,10]), pol=xr.DataArray("H"))
 
     def test_different_power_law_approximation_types(self):
         A = 5

--- a/pycomlink/tests/test_k_R_relation.py
+++ b/pycomlink/tests/test_k_R_relation.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import xarray as xr
 
 from pycomlink.processing import k_R_relation
 
@@ -24,7 +25,7 @@ class Test_a_b(unittest.TestCase):
         assert_almost_equal(0.2403, calculated_a)
         assert_almost_equal(0.9485, calculated_b)
 
-    def test_with_array(self):
+    def test_with_f_GHz_array(self):
         f_GHz = np.arange(1, 100, 0.5)
 
         pol = "V"
@@ -43,6 +44,69 @@ class Test_a_b(unittest.TestCase):
         )
 
         pol = "H"
+        a, b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
+        calculated_a = a[2::40]
+        calculated_b = b[2::40]
+        expected_a = np.array([0.0000847, 0.1155, 0.4865, 0.8974, 1.1946])
+        expected_b = np.array([1.0664, 1.0329, 0.8539, 0.7586, 0.7077])
+        assert_almost_equal(
+            expected_a,
+            calculated_a,
+        )
+        assert_almost_equal(
+            expected_b,
+            calculated_b,
+        )
+    def test_with_f_GHz_pol_array(self):
+        f_GHz = np.arange(1, 100, 0.5)
+        pol = np.repeat("V", len(f_GHz))
+        a, b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
+        calculated_a = a[2::40]
+        calculated_b = b[2::40]
+        expected_a = np.array([0.0000998, 0.117, 0.4712, 0.8889, 1.1915])
+        expected_b = np.array([0.949, 0.97, 0.8296, 0.7424, 0.6988])
+        assert_almost_equal(
+            expected_a,
+            calculated_a,
+        )
+        assert_almost_equal(
+            expected_b,
+            calculated_b,
+        )
+
+        pol = np.repeat("H", len(f_GHz))
+        a, b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
+        calculated_a = a[2::40]
+        calculated_b = b[2::40]
+        expected_a = np.array([0.0000847, 0.1155, 0.4865, 0.8974, 1.1946])
+        expected_b = np.array([1.0664, 1.0329, 0.8539, 0.7586, 0.7077])
+        assert_almost_equal(
+            expected_a,
+            calculated_a,
+        )
+        assert_almost_equal(
+            expected_b,
+            calculated_b,
+        )
+
+    def test_with_f_GHz_pol_xarray(self):
+        f_GHz = xr.DataArray(np.arange(1, 100, 0.5))
+        pol = "V"
+        a, b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
+        calculated_a = a[2::40]
+        calculated_b = b[2::40]
+        expected_a = np.array([0.0000998, 0.117, 0.4712, 0.8889, 1.1915])
+        expected_b = np.array([0.949, 0.97, 0.8296, 0.7424, 0.6988])
+        assert_almost_equal(
+            expected_a,
+            calculated_a,
+        )
+        assert_almost_equal(
+            expected_b,
+            calculated_b,
+        )
+
+        pol = xr.DataArray(np.repeat("H", len(f_GHz)))
         a, b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
         calculated_a = a[2::40]
         calculated_b = b[2::40]
@@ -155,6 +219,11 @@ class Test_calc_R_from_A(unittest.TestCase):
                 A=2, L_km=42, f_GHz=10, pol="H", a=1
             )
 
+        with self.assertRaises(ValueError):
+            # pol and F_GHz as xr.DataArray but with different size
+            calculated_R = k_R_relation.calc_R_from_A(
+                A=2, L_km=42, f_GHz=xr.DataArray([10,10]), pol=xr.DataArray("H"), a=1)
+
     def test_different_power_law_approximation_types(self):
         A = 5
         L_km = 5
@@ -205,3 +274,4 @@ class Test_calc_R_from_A(unittest.TestCase):
         expected_R = np.array([0.0, 47.24635411, 71.08341151])
         calculated_R = k_R_relation.calc_R_from_A(A[:3], L_km, f_GHz, pol)
         assert_almost_equal(expected_R, calculated_R)
+

--- a/pycomlink/tests/test_k_R_relation.py
+++ b/pycomlink/tests/test_k_R_relation.py
@@ -120,6 +120,29 @@ class Test_a_b(unittest.TestCase):
             expected_b,
             calculated_b,
         )
+    def test_with_f_GHz_mulidim_xarray(self):
+        A = 5
+        L_km = 5
+        A, Z = np.array(["A", "Z"]).view("int32")
+        cml_ids = np.random.randint(low=A, high=Z, size=198 * 4,
+                                    dtype="int32").view(f"U{4}")
+        f_GHz = xr.DataArray(
+            data=[np.arange(1, 100, 0.5)],
+            dims=['sublin_id', 'cml_id'],
+            coords=dict(
+                sublink_id='sublink_1',
+                cml_id=cml_ids, ))
+        pol = "H"
+        expected_a, expected_b = k_R_relation.a_b(f_GHz, pol, approx_type="ITU_2005")
+
+        assert_almost_equal(
+            expected_a.sum(),
+            128.67885799,
+        )
+        assert_almost_equal(
+            expected_b.sum(),
+            175.58906864,
+        )
 
     def test_interpolation(self):
         f_GHz = np.array([1.7, 28.9, 82.1])


### PR DESCRIPTION
This PR is solving #140.   

`a_b()` previously was not flexible in regard of data type of input. Now `xr.DataArray`, `np.array`, `float`(for frequency) and `str` (for polarization) are allowed.  Tests are updated to also check`xr.DataArray` as input (also with `str` vor polarization) and one new raise.

This also will help to slacken `nearby_rain_retrival()`.
 

ToDo:

- [ ] Check if example notebooks still run
- [x] Check tests