### PR TITLE
Prepare pycomlink v0.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [""3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [""3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python toolbox for deriving rainfall information from commercial microwave lin
 Installation
 ------------
 
-`pycomlink` is tested with Python 3.9, 3.10 and 3.11. There have been problems with Python 3.8, see https://github.com/pycomlink/pycomlink/pull/120. Many things might work with older version, but there is no support for this.
+`pycomlink` is tested with Python 3.10, 3.11, 3.12, and 3.13. Many things might work with older version, but there is no support for this.
 
 It can be installed via [`conda-forge`](https://conda-forge.org/):
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Christian Chwala'
 author = 'Christian Chwala'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = '0.6.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -2,6 +2,26 @@
 What's New
 **********************
 
+v0.6.0
+------
+
+Enhancements
+~~~~~~~~~~~~
+
+* Removed deprecated setuptools in favor for importlib by @maxmargraf in https://github.com/pycomlink/pycomlink/pull/179
+* Clarified cnn-based wet-dry classification docstrings by jpolz in https://github.com/pycomlink/pycomlink/pull/180
+* Updated default value and docstring for a part of the nearby rainfall retrival by @maxmargraf in https://github.com/pycomlink/pycomlink/pull/181
+
+Maintenance
+~~~~~~~~~~~~
+
+* Dropped support for python 3.9. in https://github.com/pycomlink/pycomlink/pull/181
+
+Bug fixes
+~~~~~~~~~
+
+* added a correct reshape option for cnn-based wet-dry classification by @jpolz in https://github.com/pycomlink/pycomlink/pull/176
+
 v0.5.0
 ------
 

--- a/pycomlink/processing/nearby_rain_retrival.py
+++ b/pycomlink/processing/nearby_rain_retrival.py
@@ -4,7 +4,7 @@ from pycomlink.processing.k_R_relation import a_b
 from pycomlink.processing.xarray_wrapper import xarray_apply_along_time_dim
 
 def nearby_determine_reference_level(
-        pmin, pmax, wet, n_average_dry=96, min_periods=1):
+        pmin, pmax, wet, n_average_dry=96, min_periods=10):
     """
     Determine reference/baseline level during rain events as Overeem et al.
     (2016). The baseline ist the median of all dry time steps during the last
@@ -22,15 +22,17 @@ def nearby_determine_reference_level(
         the rainfall estimation in nearby_rainfall_retrival() uses a weighted
         average between the rain rate derived from pmin and pmax. Using
         pmin to substitute pmax can lead to overestimation of rainfall.
-
     wet : xarray.DataArray
          DataArray consisting of time series with wet-dry classification.
     n_average_dry: int
-        Number of timesteps which are used to calculate the reference levek
-        (baseline) from.
+        Number of timesteps which are used to calculate the reference level
+        (baseline) from. Default is 96, based on Overeem et al 2016 which 
+	equals to 24 hours with 15 minute (min-max) data.
     min_periods: int
         Number of periods which have to be available in the last n_average_dry
-        time steps to calculate a reference level.
+        time steps to calculate a reference level. Default is 96, based on 
+	Overeem et al 2016 which equals to 2.5 hours with 15 minute (min-max) 
+	data.
 
 
     Returns

--- a/pycomlink/tests/test_nearby_rainfall.py
+++ b/pycomlink/tests/test_nearby_rainfall.py
@@ -20,7 +20,8 @@ class Test_nearby_wetdry_approach(unittest.TestCase):
         pmax = xr.DataArray(np.linspace(0, 10, len(wet)),
                             coords=dict(time=time))
 
-        res = nearby_rain.nearby_determine_reference_level(pmin, pmax, wet)
+        res = nearby_rain.nearby_determine_reference_level(
+	    pmin, pmax, wet,n_average_dry=96, min_periods=1)
 
         result = np.array(
             [np.nan, np.nan, np.nan, np.nan, np.nan,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
         "License :: OSI Approved :: BSD License",
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read(fname):
 
 setup(
     name = "pycomlink",
-    version = "0.5.0",
+    version = "0.6.0",
     author = "Christian Chwala",
     author_email = "christian.chwala@kit.edu",
     description = ("Python tools for CML (commercial microwave link) data processing"),
@@ -28,7 +28,7 @@ setup(
     keywords = "microwave links precipitation radar cml",
     url = "https://github.com/pycomlink/pycomlink",
     download_url = (
-        "https://github.com/pycomlink/pycomlink/archive/0.5.0.tar.gz"),
+        "https://github.com/pycomlink/pycomlink/archive/0.6.0.tar.gz"),
     packages=find_packages(exclude=['test']),
     include_package_data=True,
     long_description=read('README.md'),


### PR DESCRIPTION
* Drop support for python 3.9
* Change the default value to the literature value in the nearby rain retrieval to solve #172 
* Prepare version number update